### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -18,6 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions: {}
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required to pass read token to the reusable workflow for checking out private repositories.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required to pass read token to the reusable workflow for checking out private repositories.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {}
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required to pass read token to the reusable workflow for checking out private repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required to pass read token to the reusable workflow for checking out private repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to push coverage artifacts (e.g. gh-pages).
+      pull-requests: write # Required for the reusable workflow to comment on pull requests with coverage results.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -20,6 +20,7 @@ permissions: {}
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push coverage artifacts (e.g. gh-pages).
       pull-requests: write # Required for the reusable workflow to comment on pull requests with coverage results.
+    timeout-minutes: 60
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -10,6 +10,10 @@ on:
       - '**.php'
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
@@ -18,6 +22,9 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read         # Required to clone the private repository and diff files on push.
+      pull-requests: read  # Required for technote-space/get-diff-action on pull_request events.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -22,6 +22,7 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read         # Required to clone the private repository and diff files on push.
       pull-requests: read  # Required for technote-space/get-diff-action on pull_request events.

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push version bump / release branches.
       pull-requests: write # Required for the reusable workflow to open the release preparation pull request.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -23,8 +23,8 @@ jobs:
     name: Prepare Release
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
-        contents: write
-        pull-requests: write
+      contents: write      # Required for the reusable workflow to push version bump / release branches.
+      pull-requests: write # Required for the reusable workflow to open the release preparation pull request.
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,9 +3,17 @@ on:
   release:
     types:
       - created
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read      # Required to clone the private repository.
+      packages: write   # Required to publish the package to GitHub Packages with GITHUB_TOKEN.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read      # Required to clone the private repository.
       packages: write   # Required to publish the package to GitHub Packages with GITHUB_TOKEN.

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -13,6 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions: {}
     steps:
 


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 6 (`brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `lint-checker-php.yml`, `newfold-prep-release.yml`, `publish-package.yml`, `satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `1cd171f` |
| Timeouts commit | `d767515` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `publish-package.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-checker-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| publish-package.yml | 1 job was missing a scoped `permissions:` directive | publish | `contents: read`, `packages: write` [3] |
| lint-checker-php.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read`, `pull-requests: read` [2] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 0 jobs were missing a job-level `permissions:` directive | — | (none — `bluehost` / `bluehost-dev` already had `contents: read`; rationale comments were appended inline) [3] |
| newfold-prep-release.yml | 0 jobs were missing a job-level `permissions:` directive | — | (none — `prep-release` already declared permissions; indentation/comments were normalized) [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: workflow-level: BEFORE `permissions: contents: read` -> AFTER `permissions: {}` (with the required preceding comments) -- adopt default-deny at workflow scope and move least-privilege scopes exclusively to jobs -- [3] |
| 2 | `brand-plugin-test-playwright.yml` :: workflow-level: BEFORE `permissions: contents: read` -> AFTER `permissions: {}` (with the required preceding comments) -- same default-deny workflow pattern as above -- [3] |
| 3 | `brand-plugin-test-playwright.yml` :: `setup`: BEFORE `contents: read` -> AFTER `permissions: {}` -- job steps only compute branch names from environment/refs and do not check out code or call GitHub APIs with `GITHUB_TOKEN` -- [3] |
| 4 | `codecoverage-main.yml` :: `codecoverage`: reordered keys so `uses:` precedes `permissions:`; existing scopes retained with explicit inline rationale comments -- align with required job structure without widening valid `GITHUB_TOKEN` scopes -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `30` | webhook + repository-dispatch flow should finish quickly; caps wasted minutes if an action misbehaves. |
| publish-package.yml | publish | `30` | npm install/build/publish for this package should be well under a half hour; prevents hung release publishes. |
| lint-checker-php.yml | phpcs | `30` | Composer install plus PHPCS on changed PHP files should complete in minutes on typical diffs. |
| codecoverage-main.yml | get-repo-name | `15` | single-step string extraction; very short ceiling is sufficient. |
| codecoverage-main.yml | codecoverage | `60` | multi-version PHP tests plus coverage merge/publish in reusable workflow can run longer than typical lint jobs. |
| brand-plugin-test-playwright.yml | setup | `30` | branch extraction is fast but shares a conservative ceiling with other lightweight Ubuntu jobs. |
| brand-plugin-test-playwright.yml | bluehost | `60` | Playwright-driven brand-plugin builds/tests commonly exceed quick 10–15 minute jobs. |
| brand-plugin-test-playwright.yml | bluehost-dev | `60` | same rationale as `bluehost`, with an extra pinned plugin branch and artifact naming. |
| newfold-prep-release.yml | prep-release | `30` | release-prep automation should complete in under a half hour unless blocked; prevents an indefinite dispatch stall. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Attempted fetch of GitHub’s workflow `permissions` documentation timed out, so the least-privilege assessment relied on GitHub Actions’ documented permission categories (e.g. `contents`, `packages`, `pull-requests`) rather than live doc text during this audit. |
| 2 | `newfold-labs/workflows` reusable workflows (`reusable-codecoverage.yml`, `module-plugin-test-playwright.yml`, `reusable-module-prep-release.yml`) were not freshly inspected in-tree here; `contents` / `pull-requests` / `packages` choices are based on standard responsibilities of those workflow types plus the explicit token passthrough where present. |
| 3 | Confidence for `lint-checker-php.yml` `pull-requests: read` is [2] because `technote-space/get-diff-action` behavior can vary by event type; if CI proves overly strict/loose, adjust after observing a failing PR run log. |


